### PR TITLE
roundto instead of floorto in do_dragging

### DIFF
--- a/scripts/do_dragging.gml
+++ b/scripts/do_dragging.gml
@@ -1,6 +1,6 @@
 if (!keyboard_check(vk_alt)) {
-    x=floorto(global.mousex-grabx-offx,gridx)+offx
-    y=floorto(global.mousey-graby-offy,gridy)+offy
+    x=roundto(global.mousex-grabx-offx,gridx)+offx
+    y=roundto(global.mousey-graby-offy,gridy)+offy
 } else {
     x=global.mousex-grabx
     y=global.mousey-graby


### PR DESCRIPTION
currently, when you start dragging elements, you move 1 step left/up when you move the mouse 1px, but move 1 step right/down only when you move the entire grid step. this balances that movement.