### PR TITLE
ctrl+f to select objects by name

### DIFF
--- a/objects/index.yyd
+++ b/objects/index.yyd
@@ -4,3 +4,4 @@ Interface
 tileholder
 Button
 TextField
+

--- a/scripts/create.gml
+++ b/scripts/create.gml
@@ -59,6 +59,10 @@ icon_mode=0
 focus=noone
 window_focused=false
 
+searchresults=ds_list_create()
+searchmenu=N_Menu_CreatePopupMenu()
+searchmenuitems=ds_map_create()
+
 click_priority=ds_priority_create()
 
 knobz=0

--- a/scripts/globalvars.gml
+++ b/scripts/globalvars.gml
@@ -41,3 +41,4 @@ globalvar
     timelinemenu,timelinemenuitems,
     overmode,
     grabroom,
+    searchresults,searchmenu,searchmenuitems,

--- a/scripts/index.yyd
+++ b/scripts/index.yyd
@@ -144,3 +144,5 @@ delete_backups
 get_object_parent
 draw_resize_handle
 room_shift
+
+search_for_objects

--- a/scripts/search_for_objects.gml
+++ b/scripts/search_for_objects.gml
@@ -1,0 +1,84 @@
+///search_for_objects(name)
+var i,searchterm,searchtermlower,objname, exactmatch;
+var item,icon;
+var f,sprname,fn;
+
+searchterm=argument0
+searchtermlower=string_lower(searchterm)
+ds_list_clear(searchresults)
+exactmatch=""
+
+//find matching objects
+for(i=0;i<ds_list_size(objects);i+=1) {
+    objname=ds_list_find_value(objects,i)
+    if (string_pos(searchtermlower,string_lower(objname))!=0) {
+        ds_list_add(searchresults,objname)
+        if (searchtermlower==string_lower(objname)) {
+            //Technically this is ambiguous if you have 2 objects in your
+            //project which only differ in capitalization. I refuse to care.
+            exactmatch=objname
+        }
+    }
+}
+
+//resolve search
+if (ds_list_size(searchresults)==0) {
+    //no results
+    show_message("No results for '" + searchterm + "'.")
+}
+else if (ds_list_size(searchresults)==1) {
+    //single result
+    get_object(ds_list_find_value(searchresults,0))
+    textfield_set("palette name",ds_list_find_value(objects,objpal))
+}
+else {
+    //multiple results, show menu
+    ds_map_clear(searchmenuitems)
+    N_Menu_DestroyMenu(window_handle(), searchmenu)
+    searchmenu=N_Menu_CreatePopupMenu()
+
+    //start menu with exactly matching object if such exists
+    if (exactmatch!="") {
+        item=N_Menu_AddItem(searchmenu,exactmatch,"")
+        icon=object_menuicon
+        //icon code yoinked from load_object_tree
+        if (icon_mode && thumbcount<max_thumbs) {
+            f=file_text_open_read_safe(root+"objects\"+exactmatch+".txt")
+            if (f) {
+                sprname=string_delete(file_text_read_string(f),1,7) //we do a little cheating for speed
+                file_text_close(f)
+                if (sprname!="") {
+                    fn=root+"cache\sprites\"+sprname+".bmp"
+                    if (file_exists(fn)) icon=loadthumb(fn)
+                }
+            }
+        }
+        N_Menu_ItemSetBitmap(searchmenu,item,icon)
+        ds_map_add(searchmenuitems,item,exactmatch)
+
+        N_Menu_AddSeparator(searchmenu)
+    }
+
+    for(i=0;i<ds_list_size(searchresults);i+=1) {
+        objname=ds_list_find_value(searchresults,i)
+        item=N_Menu_AddItem(searchmenu,objname,"")
+        icon=object_menuicon
+        //icon code yoinked from load_object_tree
+        if (icon_mode && thumbcount<max_thumbs) {
+            f=file_text_open_read_safe(root+"objects\"+objname+".txt")
+            if (f) {
+                sprname=string_delete(file_text_read_string(f),1,7) //we do a little cheating for speed
+                file_text_close(f)
+                if (sprname!="") {
+                    fn=root+"cache\sprites\"+sprname+".bmp"
+                    if (file_exists(fn)) icon=loadthumb(fn)
+                }
+            }
+        }
+        N_Menu_ItemSetBitmap(searchmenu,item,icon)
+        ds_map_add(searchmenuitems,item,ds_list_find_value(searchresults,i))
+    }
+
+    N_Menu_ShowPopupMenu(window_handle(),searchmenu,window_get_x()+mouse_wx,window_get_y()+mouse_wy,0)
+    menutype="search"
+}

--- a/scripts/step_contextmenu.gml
+++ b/scripts/step_contextmenu.gml
@@ -107,4 +107,13 @@ if (click) {
             update_tilepanel()
         }
     }
+    if (menutype=="search") {
+        str=ds_map_get(searchmenuitems,click)
+        if (str!=undefined) {
+            if (mode==0) {
+                get_object(str)
+                textfield_set("palette name",ds_list_find_value(objects,objpal))
+            }
+        }
+    }
 }

--- a/scripts/step_hotkeys.gml
+++ b/scripts/step_hotkeys.gml
@@ -33,6 +33,12 @@ if (keyboard_check_pressed(vk_f5)) {
     alarm[3]=room_speed/2
 }
 
+if (keyboard_check(vk_control) && keyboard_check_pressed(ord("F"))) {
+    if (mode==0) {
+        search_for_objects(get_string("Object name:",""))
+    }
+}
+
 var h,v;
 
 h=keyboard_check_pressed(vk_right)-keyboard_check_pressed(vk_left)

--- a/scripts/tree.yyd
+++ b/scripts/tree.yyd
@@ -148,3 +148,4 @@
 	|draw_sprite_outline
 |draw_resize_handle
 |room_shift
+|search_for_objects


### PR DESCRIPTION
Ctrl+F in instance mode brings up search textbox. If the searched term only appears in 1 object name, it gets selected automatically, otherwise a context menu is shown. If an exact match was found, it gets placed at the top of the context menu. Search is case insensitive. Only works in instance mode partly because lazy, partly because it rapidly loses on usefulness anywhere else.
Potentially even free of memory leaks.

0 results is handled, empty input is handled.

https://user-images.githubusercontent.com/53627487/188426693-9a271807-6b2a-418f-800d-4b184134c4b8.mp4

