### PR TITLE
Fix indented annotated fields being shortened

### DIFF
--- a/source/scripts/load_object_fields.gml
+++ b/source/scripts/load_object_fields.gml
@@ -154,7 +154,7 @@ f=file_text_open_read_safe(root+"objects\"+argument1+".gml") if (f) {do {
 
             if (p) {
                 objfielddef[i,objfields[i]]=" - "+string_trim(string_delete(str,1,p+2))
-                str=string_trim(string_copy(str,1,p-1))
+                str=string_repeat(" ", fp)+string_trim(string_copy(str,1,p-1))
             }
 
             p=string_pos(": ",str)


### PR DESCRIPTION
### Bug in question:
![image](https://github.com/user-attachments/assets/fe8bac28-4ad6-4159-9342-46fa2277b552)
![image](https://github.com/user-attachments/assets/b6ca8517-2131-4473-99f9-6d183ef49e04)

I did a pretty dirty solution by just prepending the `str` with enough spaces so it doesn't loose it's original indentation.
Though I haven't tested the effect thoroughly.

I have compiled this gm82room and replaced in app dir. Works well, including with my other projects.
![image](https://github.com/user-attachments/assets/edc793aa-562f-4479-b427-5dba35c9f536)
