### PR TITLE
Fix crash when loading instance with unset font field

### DIFF
--- a/source/scripts/Font.gml
+++ b/source/scripts/Font.gml
@@ -2,6 +2,8 @@
 var f2,name,size,bold,italic,first,last,font;
 
 if (is_undefined(argument0)) return -1
+if (is_real(argument0)) return -1
+if (argument0=="") return -1
 
 if (!ds_map_exists(fontmap,argument0)) {
     if (has_fonts) {


### PR DESCRIPTION
When loading an instance that doesn't set the font field of an object which has one, gm82room crashes.
This is due to `Font` only checking for an undefined value, unlike other resource getter scripts such as `Sprite` and `Background`, which check if the value is a real or if it's an empty string.
The important part is that those check if it's a real, because if this field isn't present for a field that's interpreted as a string, the default value is 0.
`Font` not checking for this leads to it trying to add 0 to `root+"font\"`, which results in a crash.
This PR adds a check for 0 and an empty string to the font resource getter.

I'm not well versed on the internals of gm82room, so it's possible this change introduces issues with other portions of the program.